### PR TITLE
Fix comparison logic for date range equality

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -2245,7 +2245,7 @@
                         unit = 'second';
                     }
                 }
-                if (this.startDate.startOf(unit) == this.ranges[range][0].startOf(unit) == this.endDate.startOf(unit) == this.ranges[range][1].startOf(unit)) {
+                if (this.startDate.startOf(unit).equals(this.ranges[range][0].startOf(unit)) && this.endDate.startOf(unit).equals(this.ranges[range][1].startOf(unit))) {
                     customRange = false;
                     this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')').addClass('active').attr('data-range-key');
                     break;
@@ -2593,4 +2593,3 @@
 
 /** @external ISO-8601
 @see {@link https://en.wikipedia.org/wiki/ISO_8601} */
-


### PR DESCRIPTION
There is a bug in the highlighting code, where the comparison will always return `false`. 

So, even when you click a predefined range, the library sets the dates, but the subsequent highlight pass fails and “Custom Range” remains highlighted.

Looks to have been a typo where `==` was used instead of `&&`: i.e `start == start  && end == end` not `start == start == end == end`)

I've also changed the comparison to use `.equals()` , as suggested by the [luxon docs](https://moment.github.io/luxon/#/math?id=comparing-datetimes).